### PR TITLE
fix ticker_cache bug

### DIFF
--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -200,10 +200,10 @@ def get_ticker(pair: str, refresh: Optional[bool] = True) -> dict:
     global _TICKER_CACHE
     try:
         if not refresh:
-            if _TICKER_CACHE:
-                return _TICKER_CACHE
-        _TICKER_CACHE = _API.fetch_ticker(pair)
-        return _TICKER_CACHE
+            if _TICKER_CACHE and pair in _TICKER_CACHE:
+                return _TICKER_CACHE[pair]
+        _TICKER_CACHE[pair] = _API.fetch_ticker(pair)
+        return _TICKER_CACHE[pair]
     except ccxt.NetworkError as e:
         raise NetworkException(
             'Could not load tickers due to networking error. Message: {}'.format(e)


### PR DESCRIPTION
fixes a bug when caching ticker-data (as used by telegram).

causes very high ROI to show as all trades use the same "current Rate" (even though multiple trades in multiple currencies are open).

before: 
![2018-03-15-231926_409x149_scrot](https://user-images.githubusercontent.com/5024695/37494020-5ffde2c4-28a7-11e8-967f-66aa97c9eb2c.png)

![2018-03-15-232042_305x488_scrot](https://user-images.githubusercontent.com/5024695/37494042-8075dbd8-28a7-11e8-937e-bafd059c7442.png)

Notice that current_rate in the 2nd screenshot is always  0.00003580 - showing a profit of 700% for ncash - which would be nice but is not true.

after:
![2018-03-15-231933_379x115_scrot](https://user-images.githubusercontent.com/5024695/37494023-645548da-28a7-11e8-83bd-c2b0cec462d6.png)




